### PR TITLE
Add production/staging only wrapper wrapper

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,16 @@
-(defproject yleisradio/new-reliquary "1.0.0"
+(defproject clanhr/new-reliquary "1.0.0"
   :description "Clojure newrelic java api wrapper"
   :url "https://github.com/Yleisradio/new-reliquary"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.newrelic.agent.java/newrelic-api "3.17.0"]]
+
+  :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
+
+  :dependency-sets [:clojure :common]
+
+  :dependencies [[com.newrelic.agent.java/newrelic-api "3.27.0"]]
+
+  :plugins [[clanhr/shared-deps "0.2.6"]]
+
   :profiles { :dev { :dependencies [[ring/ring-core "1.3.2"]
-                                    [ring-mock "0.1.5"]
-                                    [org.clojure/tools.trace "0.7.8"]]}}
-  :plugins [[lein-ancient "0.6.7"]]
-  :signing {:gpg-key "C37817AC"})
+                                    [ring-mock "0.1.5"]]}})

--- a/src/new_reliquary/ring.clj
+++ b/src/new_reliquary/ring.clj
@@ -1,5 +1,6 @@
 (ns new-reliquary.ring
-  (:require [new-reliquary.core :as newrelic])
+  (:require [new-reliquary.core :as newrelic]
+            [environ.core :refer [env]])
   (:import (com.newrelic.api.agent Response HeaderType Request)))
 
 ; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
@@ -96,4 +97,11 @@
       response)))
 
 (defn wrap-newrelic-transaction [handler]
-  (fn [request] (newrelic/with-newrelic-transaction (web-transaction handler request))))
+  (fn [request]
+    (newrelic/with-newrelic-transaction (web-transaction handler request))))
+
+(defn wrap-prd-newrelic-transaction [handler]
+  (if (some #{"production" "staging"} [(env :clanhr-env)])
+    (fn [request]
+      (newrelic/with-newrelic-transaction (web-transaction handler request)))
+    handler))


### PR DESCRIPTION
This patch updates the newrelic lib and adds a new wrap fn that will
only hook on the pipeline if on production or staging.
