### PR TITLE
Remove shared deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,12 @@
-(defproject clanhr/new-reliquary "1.0.0"
+(defproject clanhr/new-reliquary "1.0.1"
   :description "Clojure newrelic java api wrapper"
   :url "https://github.com/Yleisradio/new-reliquary"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
-
-  :dependency-sets [:clojure :common]
-
-  :dependencies [[com.newrelic.agent.java/newrelic-api "3.27.0"]]
-
-  :plugins [[clanhr/shared-deps "0.2.6"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [environ "1.0.2"]
+                 [com.newrelic.agent.java/newrelic-api "3.27.0"]]
 
   :profiles { :dev { :dependencies [[ring/ring-core "1.3.2"]
                                     [ring-mock "0.1.5"]]}})


### PR DESCRIPTION
Motivation:

Shared deps brings a heavy burden on a project. lein deps :tree takes 60s with
shared deps, and 3s without it. So we'll start using shared deps only on the
services.
